### PR TITLE
[#1] Improve UX for admin home page

### DIFF
--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
@@ -8,6 +8,8 @@
       <textarea class="form-control" id="instructor-details-single-line" [(ngModel)]="instructorDetails"></textarea>
     </div>
 
+    <div class="top-padded error-message" *ngIf="multipleForm.hasError">{{ multipleForm.errorMessage }}</div>
+
     <div class="top-padded">
       <button class="btn btn-primary" id="add-instructor-single-line" (click)="validateAndAddInstructorDetails()">Add Instructors</button>
     </div>
@@ -34,6 +36,8 @@
       <strong>Institution: </strong>
       <input class="form-control" type="text" id="instructor-institution" [(ngModel)]="instructorInstitution">
     </div>
+
+    <div class="top-padded error-message" *ngIf="singleForm.hasError">{{ singleForm.errorMessage }}</div>
 
     <div class="top-padded">
       <button class="btn btn-primary" id="add-instructor" (click)="validateAndAddInstructorDetail()">Add Instructor</button>

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.scss
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.scss
@@ -14,3 +14,7 @@
   display: inline-block;
   width: inherit;
 }
+
+.error-message {
+  color: red;
+}

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
@@ -33,6 +33,9 @@ export class AdminHomePageComponent {
 
   isAddingInstructors: boolean = false;
 
+  singleForm: any = { hasError: false, errorMessage: '' };
+  multipleForm: any = { hasError: false, errorMessage: '' };
+
   constructor(private accountService: AccountService) {}
 
   /**
@@ -43,15 +46,18 @@ export class AdminHomePageComponent {
     for (const instructorDetail of this.instructorDetails.split(/\r?\n/)) {
       const instructorDetailSplit: string[] = instructorDetail.split(/[|\t]/).map((item: string) => item.trim());
       if (instructorDetailSplit.length < 3) {
-        // TODO handle error
+        this.multipleForm = { hasError: true, errorMessage: 'Please ensure that all 3 details have been provided.' };
         invalidLines.push(instructorDetail);
         continue;
       }
+
       if (!instructorDetailSplit[0] || !instructorDetailSplit[1] || !instructorDetailSplit[2]) {
-        // TODO handle error
+        this.multipleForm = { hasError: true, errorMessage: 'Please ensure that all 3 details have been provided.' };
         invalidLines.push(instructorDetail);
         continue;
       }
+
+      this.multipleForm = { hasError: false, errorMessage: '' }; // resets error message
       this.instructorsConsolidated.push({
         name: instructorDetailSplit[0],
         email: instructorDetailSplit[1],
@@ -67,9 +73,17 @@ export class AdminHomePageComponent {
    */
   validateAndAddInstructorDetail(): void {
     if (!this.instructorName || !this.instructorEmail || !this.instructorInstitution) {
-      // TODO handle error
+      this.singleForm = { hasError: true, errorMessage: 'Please fill in all fields.' };
       return;
     }
+
+    const re = /[A-Za-z0-9._%-]+@[A-Za-z0-9._%-]+\.[a-z]{2,3}/;
+    if (!re.test(this.instructorEmail)) {
+      this.singleForm = { hasError: true, errorMessage: 'Please provide a valid email.' };
+      return;
+    }
+
+    this.singleForm = { hasError: false, errorMessage: '' }; // resets error message
     this.instructorsConsolidated.push({
       name: this.instructorName,
       email: this.instructorEmail,

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
@@ -57,6 +57,12 @@ export class AdminHomePageComponent {
         continue;
       }
 
+      const re = /[A-Za-z0-9._%-]+@[A-Za-z0-9._%-]+\.[a-z]{2,3}/;
+      if (!re.test(instructorDetailSplit[1])) {
+        this.multipleForm = { hasError: true, errorMessage: 'Please provide valid email(s) for all instructor(s).' };
+        return;
+      }
+
       this.multipleForm = { hasError: false, errorMessage: '' }; // resets error message
       this.instructorsConsolidated.push({
         name: instructorDetailSplit[0],


### PR DESCRIPTION
Fixes #1

**Outline of Solution**

<!-- Explain your change. -->
In this PR, error messages were added to the admin's home page.

Previously, when the user (an admin) performed actions that led to errors, no error message will be shown on the page. This PR aims to improve user experience by providing users with feedback, in the form of an error message, so that users would be made aware that something went wrong and what exactly went wrong.

The changes made in this PR are listed below:
1. Under "Adding Multiple Instructors", no error message was thrown if one of the fields (i.e. name/email/institution) was left empty. ![image](https://user-images.githubusercontent.com/55139982/127767914-7086c4bc-fba4-4aa0-b7c6-8d11af07762e.png)

    This has since been updated to display an error message to inform the user that one of the fields has been accidentally left empty, so that he/she would be prompted to re-check their submission. 
![image](https://user-images.githubusercontent.com/55139982/127767976-0baf9360-54b0-4660-a6eb-4cc93396b35c.png)

1. Under "Adding a Single Instructor", no error message was thrown if one of the fields was left empty as well. ![image](https://user-images.githubusercontent.com/55139982/127767940-573659ea-7851-446e-af90-6b20f1e04153.png)

    This has since been updated to display an error message to inform the user that one of the fields has been accidentally left empty, so that he/she would be prompted to re-check their submission. 
![image](https://user-images.githubusercontent.com/55139982/127768000-30642877-e2b4-4f94-96ea-9740656018e9.png)

1. An email validator has been added to ensure that only valid emails would be accepted as input. Previously, invalid emails (such as the example below) would be accepted by the form. ![image](https://user-images.githubusercontent.com/55139982/127767895-77deadb6-da1e-42c1-b4f0-01978ac58af7.png)

    This has been updated to display an error message when an invalid email has been provided by the user, ensuring that all emails in the database are valid addresses.
![image](https://user-images.githubusercontent.com/55139982/127767829-8c4d17be-26a0-4c9d-ae17-f460c6d4e118.png)
![image](https://user-images.githubusercontent.com/55139982/127767850-93f3cc75-bcb7-44be-b845-952e79bec458.png)
    (Note: valid emails are email addresses of the format \<username\>@\<domain\>, where \<domain\> should contain a '.' followed by a valid domain name.)